### PR TITLE
refactor(nvim-tree-integration): unify add/drop logic and remove hard coded key bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
 - [x] 📤 Send buffers or selections to Aider
 - [x] 💬 Optional user prompt for buffer and selection sends
 - [x] 🔍 Aider command selection UI with fuzzy search and input prompt
+- [x] 🌳 Integration with [nvim-tree.lua](https://github.com/nvim-tree/nvim-tree.lua)
+      for adding or dropping files directly from the tree interface
 
 ## 🎮 Commands
 
@@ -56,7 +58,7 @@ Using lazy.nvim:
       { "<leader>ab", "<cmd>AiderQuickSendBuffer<cr>", desc = "Send Buffer To Aider" },
       { "<leader>a+", "<cmd>AiderQuickAddFile<cr>", desc = "Add File to Aider" },
       { "<leader>a-", "<cmd>AiderQuickDropFile<cr>", desc = "Drop File from Aider" },
-      -- nvim-tree.lua integration
+      -- Example nvim-tree.lua integration if needed
       { "<leader>a+", "<cmd>AiderTreeAddFile<cr>", desc = "Add File from Tree to Aider", ft = "NvimTree" },
       { "<leader>a-", "<cmd>AiderTreeDropFile<cr>", desc = "Drop File from Tree from Aider", ft = "NvimTree" },
     },
@@ -65,6 +67,7 @@ Using lazy.nvim:
       "nvim-telescope/telescope.nvim",
       --- The below dependencies are optional
       "catppuccin/nvim",
+      "nvim-tree/nvim-tree.lua",
     },
     config = true,
   }

--- a/lua/nvim_aider/init.lua
+++ b/lua/nvim_aider/init.lua
@@ -98,7 +98,7 @@ function M.setup(opts)
   end, {})
 
   -- Setup nvim-tree integration
-  require("nvim_aider.tree").setup()
+  require("nvim_aider.tree").setup(opts)
 end
 
 return M

--- a/lua/nvim_aider/tree.lua
+++ b/lua/nvim_aider/tree.lua
@@ -3,121 +3,67 @@ local M = {}
 local commands = require("nvim_aider.commands")
 local terminal = require("nvim_aider.terminal")
 
-local function add_file_from_tree()
-  -- Check if we're in a nvim-tree buffer
+local function handle_file_from_tree(cmd_value)
+  -- Ensure we're in a nvim-tree buffer
   if vim.bo.filetype ~= "NvimTree" then
     vim.notify("Not in nvim-tree buffer", vim.log.levels.WARN)
     return
   end
 
-  local ok, nvim_tree = pcall(require, "nvim-tree.api")
+  local ok, nvim_tree_api = pcall(require, "nvim-tree.api")
   if not ok then
     vim.notify("nvim-tree plugin is not installed", vim.log.levels.ERROR)
     return
   end
 
-  if not nvim_tree.tree then
+  if not nvim_tree_api.tree then
     vim.notify("nvim-tree API has changed - please update the plugin", vim.log.levels.ERROR)
     return
   end
 
-  -- Get the node under cursor safely
-  local node
-  local ok2, result = pcall(function()
-    if not nvim_tree.tree then
-      error("nvim-tree API has changed - tree field is missing")
-    end
-    return nvim_tree.tree.get_node_under_cursor()
+  -- Safely get node under cursor
+  local ok2, node_or_err = pcall(function()
+    return nvim_tree_api.tree.get_node_under_cursor()
   end)
 
   if not ok2 then
-    vim.notify("Error getting node: " .. tostring(result), vim.log.levels.ERROR)
+    vim.notify("Error getting node: " .. tostring(node_or_err), vim.log.levels.ERROR)
     return
   end
 
-  node = result
+  local node = node_or_err
   if not node then
     vim.notify("No node found under cursor", vim.log.levels.WARN)
     return
   end
-  if node and node.absolute_path then
-    local relative_path = vim.fn.fnamemodify(node.absolute_path, ":.")
-    terminal.command(commands.add.value, relative_path)
-  else
+
+  if not node.absolute_path then
     vim.notify("No valid file selected in nvim-tree", vim.log.levels.WARN)
+    return
   end
+
+  local relative_path = vim.fn.fnamemodify(node.absolute_path, ":.")
+  terminal.command(cmd_value, relative_path)
+end
+
+local function add_file_from_tree()
+  handle_file_from_tree(commands.add.value)
 end
 
 local function drop_file_from_tree()
-  -- Check if we're in a nvim-tree buffer
-  if vim.bo.filetype ~= "NvimTree" then
-    vim.notify("Not in nvim-tree buffer", vim.log.levels.WARN)
-    return
-  end
-
-  local ok, nvim_tree = pcall(require, "nvim-tree.api")
-  if not ok then
-    vim.notify("nvim-tree plugin is not installed", vim.log.levels.ERROR)
-    return
-  end
-
-  if not nvim_tree.tree then
-    vim.notify("nvim-tree API has changed - please update the plugin", vim.log.levels.ERROR)
-    return
-  end
-
-  -- Get the node under cursor safely
-  local node
-  local ok2, result = pcall(function()
-    if not nvim_tree.tree then
-      error("nvim-tree API has changed - tree field is missing")
-    end
-    return nvim_tree.tree.get_node_under_cursor()
-  end)
-
-  if not ok2 then
-    vim.notify("Error getting node: " .. tostring(result), vim.log.levels.ERROR)
-    return
-  end
-
-  node = result
-  if not node then
-    vim.notify("No node found under cursor", vim.log.levels.WARN)
-    return
-  end
-  if node and node.absolute_path then
-    local relative_path = vim.fn.fnamemodify(node.absolute_path, ":.")
-    terminal.command(commands.drop.value, relative_path)
-  else
-    vim.notify("No valid file selected in nvim-tree", vim.log.levels.WARN)
-  end
+  handle_file_from_tree(commands.drop.value)
 end
 
-function M.setup()
-  -- Setup nvim-tree commands
-  vim.api.nvim_create_user_command("AiderTreeAddFile", add_file_from_tree, {
-    desc = "Add file from nvim-tree to Aider chat",
-  })
-
-  vim.api.nvim_create_user_command("AiderTreeDropFile", drop_file_from_tree, {
-    desc = "Drop file from nvim-tree from Aider chat",
-  })
-
-  -- Set up nvim-tree keymaps if available
+---@param opts? nvim_aider.Config
+function M.setup(opts)
   local ok, _ = pcall(require, "nvim-tree")
   if ok then
-    vim.api.nvim_create_autocmd("FileType", {
-      pattern = "NvimTree",
-      callback = function()
-        vim.keymap.set("n", "<leader>a+", "<cmd>AiderTreeAddFile<cr>", {
-          buffer = true,
-          desc = "Add file from tree to Aider",
-        })
-        vim.keymap.set("n", "<leader>a-", "<cmd>AiderTreeDropFile<cr>", {
-          buffer = true,
-          desc = "Drop file from tree from Aider",
-        })
-      end,
+    vim.api.nvim_create_user_command("AiderTreeAddFile", add_file_from_tree, {
+      desc = "Add file from nvim-tree to Aider chat",
+    })
+
+    vim.api.nvim_create_user_command("AiderTreeDropFile", drop_file_from_tree, {
+      desc = "Drop file from nvim-tree from Aider chat",
     })
   end
 end

--- a/tests/minit.lua
+++ b/tests/minit.lua
@@ -39,6 +39,7 @@ require("lazy.minit").setup({
         "nvim-telescope/telescope.nvim",
         --- The below dependencies are optional
         "catppuccin/nvim",
+        "nvim-tree/nvim-tree.lua",
       },
       config = true,
     },

--- a/tests/nvim_tree_spec.lua
+++ b/tests/nvim_tree_spec.lua
@@ -1,4 +1,3 @@
-local mock = require("luassert.mock")
 local stub = require("luassert.stub")
 
 describe("nvim-tree integration", function()


### PR DESCRIPTION
- Removes the autocmd-based key mapping setup within the plugin code in favor of allowing the user to configure key bindings externally (for example, through a plugin manager like Lazy). This approach avoids overriding user-defined custom mappings and gives more flexibility in user configurations.

Happy to merge your PR if your are fine with my changes. 